### PR TITLE
Turn off swapfiles

### DIFF
--- a/lua/vimconfig.lua
+++ b/lua/vimconfig.lua
@@ -110,3 +110,6 @@ vim.o.statuscolumn = ""
 
 vim.keymap.set("n", "<leader>ld", vim.diagnostic.open_float)
 vim.keymap.set("n", "<leader>la", vim.lsp.buf.code_action)
+
+-- Swap file
+vim.o.swapfile = false


### PR DESCRIPTION
Was getting a strange bug where, while a nix devshell was open in a directory, neovim would show an outdated version of files there. The issue was fixed by disabling swap files.