### PR TITLE
Push lrmzqvqtrnkr

### DIFF
--- a/lua/config/lazy.lua
+++ b/lua/config/lazy.lua
@@ -1,30 +1,29 @@
 -- Bootstrap lazy.nvim
 local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
 if not (vim.uv or vim.loop).fs_stat(lazypath) then
-  local lazyrepo = "https://github.com/folke/lazy.nvim.git"
-  local out = vim.fn.system({ "git", "clone", "--filter=blob:none", "--branch=stable", lazyrepo, lazypath })
-  if vim.v.shell_error ~= 0 then
-    vim.api.nvim_echo({
-      { "Failed to clone lazy.nvim:\n", "ErrorMsg" },
-      { out, "WarningMsg" },
-      { "\nPress any key to exit..." },
-    }, true, {})
-    vim.fn.getchar()
-    os.exit(1)
-  end
+	local lazyrepo = "https://github.com/folke/lazy.nvim.git"
+	local out = vim.fn.system({ "git", "clone", "--filter=blob:none", "--branch=stable", lazyrepo, lazypath })
+	if vim.v.shell_error ~= 0 then
+		vim.api.nvim_echo({
+			{ "Failed to clone lazy.nvim:\n", "ErrorMsg" },
+			{ out, "WarningMsg" },
+			{ "\nPress any key to exit..." },
+		}, true, {})
+		vim.fn.getchar()
+		os.exit(1)
+	end
 end
 vim.opt.rtp:prepend(lazypath)
 
 -- Setup lazy.nvim
 require("lazy").setup({
-  spec = {
-    -- import your plugins
-    { import = "plugins" },
-  },
-  -- Configure any other settings here. See the documentation for more details.
-  -- colorscheme that will be used when installing plugins.
-  -- install = { colorscheme = { "habamax" } },
-  -- automatically check for plugin updates
-  checker = { enabled = true },
+	spec = {
+		-- import your plugins
+		{ import = "plugins" },
+	},
+	-- Configure any other settings here. See the documentation for more details.
+	-- colorscheme that will be used when installing plugins.
+	-- install = { colorscheme = { "habamax" } },
+	-- automatically check for plugin updates
+	checker = { enabled = true, notify = false },
 })
-

--- a/lua/plugins/dap.lua
+++ b/lua/plugins/dap.lua
@@ -1,0 +1,285 @@
+local js_based_languages = {
+	"typescript",
+	"javascript",
+	"typescriptreact",
+	"javascriptreact",
+	"svelte",
+}
+
+return {
+	"mfussenegger/nvim-dap",
+	dependencies = {
+		{ "rcarriga/nvim-dap-ui", dependencies = { "mfussenegger/nvim-dap", "nvim-neotest/nvim-nio" } },
+		"mason-org/mason.nvim",
+		"jay-babu/mason-nvim-dap.nvim",
+		{
+			"microsoft/vscode-js-debug",
+			build = "npm install --legacy-peer-deps --no-save && npx gulp vsDebugServerBundle && rm -rf out && mv dist out",
+			version = "1.*",
+		},
+		{
+			"mxsdev/nvim-dap-vscode-js",
+			config = function()
+				---@diagnostic disable-next-line: missing-fields
+				require("dap-vscode-js").setup({
+					-- Path of node executable. Defaults to $NODE_PATH, and then "node"
+					-- node_path = "node",
+
+					-- Path to vscode-js-debug installation.
+					debugger_path = vim.fn.resolve(vim.fn.stdpath("data") .. "/lazy/vscode-js-debug"),
+
+					-- Command to use to launch the debug server. Takes precedence over "node_path" and "debugger_path"
+					-- debugger_cmd = { "js-debug-adapter" },
+
+					-- which adapters to register in nvim-dap
+					adapters = {
+						"chrome",
+						"pwa-node",
+						"pwa-chrome",
+						"pwa-msedge",
+						"pwa-extensionHost",
+						"node-terminal",
+					},
+
+					-- Path for file logging
+					-- log_file_path = "(stdpath cache)/dap_vscode_js.log",
+
+					-- Logging level for output to file. Set to false to disable logging.
+					-- log_file_level = false,
+
+					-- Logging level for output to console. Set to false to disable console output.
+					-- log_console_level = vim.log.levels.ERROR,
+				})
+			end,
+		},
+		{
+			"Joakker/lua-json5",
+			build = "./install.sh",
+		},
+	},
+	config = function()
+		local dap = require("dap")
+		local dapui = require("dapui")
+
+		require("mason-nvim-dap").setup({
+			automatic_installation = true,
+			handlers = {},
+			ensure_installed = {},
+		})
+
+		dapui.setup({
+			icons = { expanded = "▾", collapsed = "▸", current_frame = "*" },
+			controls = {
+				icons = {
+					pause = "⏸",
+					play = "▶",
+					step_into = "⏎",
+					step_over = "⏭",
+					step_out = "⏮",
+					step_back = "b",
+					run_last = "▶▶",
+					terminate = "⏹",
+					disconnect = "⏏",
+				},
+			},
+		})
+
+		dap.listeners.after.event_initialized["dapui_config"] = dapui.open
+		dap.listeners.before.event_terminated["dapui_config"] = dapui.close
+		dap.listeners.before.event_exited["dapui_config"] = dapui.close
+
+		for _, language in ipairs(js_based_languages) do
+			dap.configurations[language] = {
+				-- Single nodejs files
+				{
+					type = "pwa-node",
+					request = "launch",
+					name = "Launch Program",
+					program = "${file}",
+					cwd = vim.fn.getcwd(),
+					sourceMaps = true,
+				},
+				-- nodejs processes
+				{
+					type = "pwa-node",
+					request = "attach",
+					name = "Attach to Process",
+					processId = require("dap.utils").pick_process,
+					cwd = vim.fn.getcwd(),
+					sourceMaps = true,
+				},
+				-- Web apps
+				{
+					type = "pwa-chrome",
+					request = "launch",
+					name = "Launch Chrome against localhost",
+					url = function()
+						local co = coroutine.running()
+						return coroutine.create(function()
+							vim.ui.input({
+								prompt = "URL: ",
+								default = "http://localhost:3000",
+							}, function(url)
+								if url == nil or url == "" then
+									return
+								else
+									coroutine.resume(co, url)
+								end
+							end)
+						end)
+					end,
+					webRoot = "${workspaceFolder}",
+					protocol = "inspector",
+					sourceMaps = true,
+					userDataDir = false,
+				},
+			}
+		end
+	end,
+	keys = {
+		{
+			"<leader>dB",
+			function()
+				require("dap").set_breakpoint(vim.fn.input("Breakpoint condition: "))
+			end,
+			desc = "Breakpoint Condition",
+		},
+		{
+			"<leader>db",
+			function()
+				require("dap").toggle_breakpoint()
+			end,
+			desc = "Toggle Breakpoint",
+		},
+		{
+			"<leader>dc",
+			function()
+				require("dap").continue()
+			end,
+			desc = "Run/Continue",
+		},
+		{
+			"<leader>da",
+			function()
+				require("dap").continue({ before = get_args })
+			end,
+			desc = "Run with Args",
+		},
+		{
+			"<leader>dC",
+			function()
+				require("dap").run_to_cursor()
+			end,
+			desc = "Run to Cursor",
+		},
+		{
+			"<leader>dg",
+			function()
+				require("dap").goto_()
+			end,
+			desc = "Go to Line (No Execute)",
+		},
+		{
+			"<leader>di",
+			function()
+				require("dap").step_into()
+			end,
+			desc = "Step Into",
+		},
+		{
+			"<leader>dj",
+			function()
+				require("dap").down()
+			end,
+			desc = "Down",
+		},
+		{
+			"<leader>dk",
+			function()
+				require("dap").up()
+			end,
+			desc = "Up",
+		},
+		{
+			"<leader>dl",
+			function()
+				require("dap").run_last()
+			end,
+			desc = "Run Last",
+		},
+		{
+			"<leader>do",
+			function()
+				require("dap").step_out()
+			end,
+			desc = "Step Out",
+		},
+		{
+			"<leader>dO",
+			function()
+				require("dap").step_over()
+			end,
+			desc = "Step Over",
+		},
+		{
+			"<leader>dP",
+			function()
+				require("dap").pause()
+			end,
+			desc = "Pause",
+		},
+		{
+			"<leader>dr",
+			function()
+				require("dap").repl.toggle()
+			end,
+			desc = "Toggle REPL",
+		},
+		{
+			"<leader>ds",
+			function()
+				require("dap").session()
+			end,
+			desc = "Session",
+		},
+		{
+			"<leader>dt",
+			function()
+				require("dap").terminate()
+			end,
+			desc = "Terminate",
+		},
+		{
+			"<leader>dw",
+			function()
+				require("dap.ui.widgets").hover()
+			end,
+			desc = "Widgets",
+		},
+		{
+			"<leader>dO",
+			"<cmd>lua require('dap').step_out()<cr>",
+			desc = "Step Out",
+		},
+		{
+			"<leader>do",
+			"<cmd>lua require('dap').step_over()<cr>",
+			desc = "Step Over",
+		},
+		{
+			"<leader>da",
+			function()
+				if vim.fn.filereadable(".vscode/launch.json") then
+					local dap_vscode = require("dap.ext.vscode")
+					dap_vscode.load_launchjs(nil, {
+						["pwa-node"] = js_based_languages,
+						["chrome"] = js_based_languages,
+						["pwa-chrome"] = js_based_languages,
+					})
+				end
+				require("dap").continue()
+			end,
+			desc = "Run with Args",
+		},
+	},
+}

--- a/lua/plugins/dapui.lua
+++ b/lua/plugins/dapui.lua
@@ -1,0 +1,4 @@
+return {
+	"rcarriga/nvim-dap-ui",
+	dependencies = { "mfussenegger/nvim-dap", "nvim-neotest/nvim-nio" },
+}

--- a/lua/plugins/kulala.lua
+++ b/lua/plugins/kulala.lua
@@ -1,0 +1,14 @@
+return {
+  "mistweaverco/kulala.nvim",
+  opts = {
+    global_keymaps = true,
+    global_keymaps_prefix = "<leader>R",
+    kuala_keymaps_prefix = "",
+    syntax_hl = {
+      ["@punctuation.bracket.kulala_http"] = "Number",
+      ["@character.special.kulala_http"] = "Special",
+      ["@operator.kulala_http"] = "Special",
+      ["@variable.kulala_http"] = "String",
+    },
+  },
+}

--- a/lua/plugins/treesitter.lua
+++ b/lua/plugins/treesitter.lua
@@ -1,8 +1,8 @@
 return {
 	"nvim-treesitter/nvim-treesitter",
-	config = function()
-		vim.cmd("TSUpdate")
-	end,
+	--config = function()
+	--	vim.cmd("TSUpdate")
+	--end,
 	setup = {
 		ensure_installed = { "c", "lua", "markdown", "markdown_inline", "typescript", "javascript", "svelte" },
 	},

--- a/lua/vimconfig.lua
+++ b/lua/vimconfig.lua
@@ -113,3 +113,16 @@ vim.keymap.set("n", "<leader>la", vim.lsp.buf.code_action)
 
 -- Swap file
 vim.o.swapfile = false
+
+-- Remove theme background
+vim.api.nvim_create_autocmd('ColorScheme', {
+  callback = function()
+    vim.cmd [[
+      highlight Normal guibg=none
+      highlight NonText guibg=none
+      highlight Normal ctermbg=none
+      highlight NonText ctermbg=none
+    ]]
+  end,
+})
+


### PR DESCRIPTION
# What
- Whenever the colour scheme is changed, make the background transparent

# Why
- Changed terminal from Kitty to Ghostty, resulting in the 'quiet' default nvim theme no longer having the same background as the terminal
- Autocommand is required because colour scheme is set _after_ the contents of `vimconfig.lua` are called